### PR TITLE
Replace use of `maven-antrun-plugin` with `download-maven-plugin`

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -275,37 +275,42 @@
         </executions>
       </plugin>
       <plugin>
-        <artifactId>maven-antrun-plugin</artifactId>
-        <version>3.1.0</version>
+        <groupId>io.github.download-maven-plugin</groupId>
+        <artifactId>download-maven-plugin</artifactId>
+        <version>2.0.0</version>
         <executions>
           <execution>
-            <id>default-download-executables</id>
+            <id>default-download-pl</id>
             <phase>initialize</phase>
             <goals>
-              <goal>run</goal>
+              <goal>wget</goal>
             </goals>
             <configuration>
-              <target>
-                <exec executable="curl" dir="${project.build.outputDirectory}">
-                  <arg value="-s" />
-                  <arg value="-L" />
-                  <arg value="${cloc.url}/releases/download/v${cloc.version}/cloc-${cloc.version}.exe" />
-                  <arg value="-o" />
-                  <arg value="cloc.exe" />
-                  <arg value="-L" />
-                  <arg value="${cloc.url}/releases/download/v${cloc.version}/cloc-${cloc.version}.pl" />
-                  <arg value="-o" />
-                  <arg value="cloc.pl" />
-                </exec>
-                <exec executable="chmod" dir="${project.build.outputDirectory}">
-                  <arg value="+x" />
-                  <arg value="cloc.exe" />
-                  <arg value="cloc.pl" />
-                </exec>
-              </target>
+              <url>${cloc.url}/releases/download/v${cloc.version}/cloc-${cloc.version}.pl</url>
+              <outputFileName>cloc.pl</outputFileName>
+              <md5>31533dd445610364154ec328bfcf7b2c</md5>
+            </configuration>
+          </execution>
+          <execution>
+            <id>default-download-exe</id>
+            <phase>initialize</phase>
+            <goals>
+              <goal>wget</goal>
+            </goals>
+            <configuration>
+              <url>${cloc.url}/releases/download/v${cloc.version}/cloc-${cloc.version}.exe</url>
+              <outputFileName>cloc.exe</outputFileName>
+              <md5>31adac93c8d3c9e4d67912a8f9f5b729</md5>
             </configuration>
           </execution>
         </executions>
+        <configuration>
+          <outputDirectory>${project.build.outputDirectory}</outputDirectory>
+          <outputFilePermissions>+x</outputFilePermissions>
+          <alwaysVerifyChecksum>true</alwaysVerifyChecksum>
+          <failOnError>true</failOnError>
+          <overwrite>true</overwrite>
+        </configuration>
       </plugin>
     </plugins>
   </build>


### PR DESCRIPTION
Closes #38

Switched to the `download-maven-plugin` to simplify the process of downloading the `cloc` executables. This reduces reliance on custom Ant tasks and improves configuration clarity. Added checksum verification and other safeguards to ensure reliability.