### PR TITLE
Add `cloc.properties` and access APIs

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -122,6 +122,12 @@
   </dependencies>
 
   <build>
+    <resources>
+      <resource>
+        <directory>${project.basedir}/src/main/resources</directory>
+        <filtering>true</filtering>
+      </resource>
+    </resources>
     <plugins>
       <plugin>
         <artifactId>maven-clean-plugin</artifactId>
@@ -130,6 +136,9 @@
       <plugin>
         <artifactId>maven-resources-plugin</artifactId>
         <version>3.3.1</version>
+        <configuration>
+          <propertiesEncoding>UTF-8</propertiesEncoding>
+        </configuration>
       </plugin>
       <plugin>
         <artifactId>maven-enforcer-plugin</artifactId>

--- a/src/main/java/ch/usi/si/seart/cloc/CLOC.java
+++ b/src/main/java/ch/usi/si/seart/cloc/CLOC.java
@@ -15,6 +15,7 @@ import org.jetbrains.annotations.Nullable;
 
 import java.io.File;
 import java.io.IOException;
+import java.io.InputStream;
 import java.io.UncheckedIOException;
 import java.net.URL;
 import java.nio.file.Path;
@@ -22,6 +23,7 @@ import java.util.LinkedHashMap;
 import java.util.LinkedHashSet;
 import java.util.Map;
 import java.util.Objects;
+import java.util.Properties;
 import java.util.Set;
 import java.util.function.Consumer;
 import java.util.stream.Collectors;
@@ -47,6 +49,39 @@ public final class CLOC {
     private CLOC(CommandLine commandLine, int timeout) {
         this.commandLine = commandLine;
         this.timeout = timeout;
+    }
+
+    private static volatile Properties properties;
+
+    private static Properties properties() {
+        if (properties == null) {
+            synchronized (CLOC.class) {
+                if (properties == null) {
+                    properties = new Properties();
+                    try (InputStream stream = CLOC.class.getClassLoader().getResourceAsStream("cloc.properties")) {
+                        properties.load(stream);
+                    } catch (IOException ignored) {
+                    }
+                }
+            }
+        }
+        return properties;
+    }
+
+    /**
+     * @return the {@code cloc} repository link, or {@code null} if the details could not be loaded.
+     */
+    @Nullable
+    public static String getURL() {
+        return properties().getProperty("cloc.url");
+    }
+
+    /**
+     * @return the {@code cloc} command version, or {@code null} if the details could not be loaded.
+     */
+    @Nullable
+    public static String getVersion() {
+        return properties().getProperty("cloc.version");
     }
 
     /**

--- a/src/main/resources/cloc.properties
+++ b/src/main/resources/cloc.properties
@@ -1,0 +1,2 @@
+cloc.url=${cloc.url}
+cloc.version=${cloc.version}

--- a/src/test/java/ch/usi/si/seart/cloc/CLOCTest.java
+++ b/src/test/java/ch/usi/si/seart/cloc/CLOCTest.java
@@ -79,4 +79,18 @@ class CLOCTest {
         Assertions.assertEquals(files.size(), header.get("n_files").asInt());
         Assertions.assertEquals(files.size() + 2, result.size());
     }
+
+    @Test
+    void testGetURL() {
+        String url = CLOC.getURL();
+        Assertions.assertNotNull(url, "URL should not be null.");
+        Assertions.assertFalse(url.isEmpty(), "URL should not be empty.");
+    }
+
+    @Test
+    void testGetVersion() {
+        String version = CLOC.getVersion();
+        Assertions.assertNotNull(version, "Version should not be null.");
+        Assertions.assertFalse(version.isEmpty(), "Version should not be empty.");
+    }
 }


### PR DESCRIPTION
Rather than executing the bundled `cloc` command at runtime to retrieve the version, we instead create a `cloc.properties` file that can be read at runtime. Currently consists of `cloc.url` and `cloc.version`, both of which are defined in `pom.xml`. We also make use of the `maven-resources-plugin` to generate the file contents at build time. Finally, the properties are loaded lazily, only once requested.

Closes #41