### PR TITLE
Use only `cloc.pl` on both Unix and Windows

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -39,6 +39,8 @@ jobs:
     steps:
       - name: Checkout latest
         uses: actions/checkout@v4
+      - name: Set up Perl
+        uses: shogo82148/actions-setup-perl@v1.31.4
       - name: Set up JDK 8
         uses: actions/setup-java@v4
         with:
@@ -55,6 +57,8 @@ jobs:
     steps:
       - name: Checkout latest
         uses: actions/checkout@v4
+      - name: Set up Perl
+        uses: shogo82148/actions-setup-perl@v1.31.4
       - name: Set up JDK 8
         uses: actions/setup-java@v4
         with:

--- a/README.md
+++ b/README.md
@@ -14,8 +14,12 @@ following dependency in your Maven project:
 ## Requirements
 
 This library requires a minimum of Java 8. You don't need to have `cloc` installed on your system, as the JAR comes
-bundled with the necessary script. Since it is written in Perl, it should be executable out of the box on most systems
-(as the majority of Unix-like systems have it installed by default).
+bundled with the necessary script.
+
+> [!NOTE]  
+> Since this script is written in Perl, you must make sure that its interpreter is installed and located on your `PATH`.
+> Should work out of the box on most systems (as the majority of Unix-like systems have it installed by default),
+> but worth pointing out in case you plan on using this on a minimalistic Linux image or Windows.
 
 ## Example
 

--- a/doc/README.md
+++ b/doc/README.md
@@ -14,8 +14,12 @@ following dependency in your Maven project:
 ## Requirements
 
 This library requires a minimum of Java 8. You don't need to have `cloc` installed on your system, as the JAR comes
-bundled with the necessary script. Since it is written in Perl, it should be executable out of the box on most systems
-(as the majority of Unix-like systems have it installed by default).
+bundled with the necessary script.
+
+> [!NOTE]  
+> Since this script is written in Perl, you must make sure that its interpreter is installed and located on your `PATH`.
+> Should work out of the box on most systems (as the majority of Unix-like systems have it installed by default),
+> but worth pointing out in case you plan on using this on a minimalistic Linux image or Windows.
 
 ## Example
 

--- a/pom.xml
+++ b/pom.xml
@@ -62,6 +62,7 @@
     <java.version>8</java.version>
     <cloc.version>2.02</cloc.version>
     <cloc.url>https://github.com/AlDanial/cloc</cloc.url>
+    <cloc.md5>31533dd445610364154ec328bfcf7b2c</cloc.md5>
     <org.apache.commons-lang.version>3.17.0</org.apache.commons-lang.version>
     <org.codehaus.plexus.version>4.0.2</org.codehaus.plexus.version>
     <org.jetbrains.annotations.version>26.0.1</org.jetbrains.annotations.version>
@@ -297,7 +298,7 @@
             <configuration>
               <url>${cloc.url}/releases/download/v${cloc.version}/cloc-${cloc.version}.pl</url>
               <outputFileName>cloc.pl</outputFileName>
-              <md5>31533dd445610364154ec328bfcf7b2c</md5>
+              <md5>${cloc.md5}</md5>
             </configuration>
           </execution>
         </executions>

--- a/pom.xml
+++ b/pom.xml
@@ -300,18 +300,6 @@
               <md5>31533dd445610364154ec328bfcf7b2c</md5>
             </configuration>
           </execution>
-          <execution>
-            <id>default-download-exe</id>
-            <phase>initialize</phase>
-            <goals>
-              <goal>wget</goal>
-            </goals>
-            <configuration>
-              <url>${cloc.url}/releases/download/v${cloc.version}/cloc-${cloc.version}.exe</url>
-              <outputFileName>cloc.exe</outputFileName>
-              <md5>31adac93c8d3c9e4d67912a8f9f5b729</md5>
-            </configuration>
-          </execution>
         </executions>
         <configuration>
           <outputDirectory>${project.build.outputDirectory}</outputDirectory>

--- a/src/main/java/ch/usi/si/seart/cloc/CLOC.java
+++ b/src/main/java/ch/usi/si/seart/cloc/CLOC.java
@@ -78,7 +78,7 @@ public final class CLOC {
                             break;
                         case "jar":
                             try {
-                                File script = new File(SystemUtils.JAVA_IO_TMPDIR, "cloc.pl");
+                                File script = new File(SystemUtils.USER_HOME, "cloc.pl");
                                 if (getMD5() != null && script.exists() && MD5.hash(script).equals(getMD5())) {
                                     EXECUTABLE = script;
                                     break;

--- a/src/main/java/ch/usi/si/seart/cloc/CLOC.java
+++ b/src/main/java/ch/usi/si/seart/cloc/CLOC.java
@@ -84,6 +84,14 @@ public final class CLOC {
     }
 
     /**
+     * @return the {@code cloc} executable MD5 checksum, or {@code null} if the details could not be loaded.
+     */
+    @Nullable
+    public static String getMD5() {
+        return getProperties().getProperty("cloc.md5");
+    }
+
+    /**
      * Set the {@link JsonMapper} to use for parsing the output of the command.
      *
      * @param mapper the mapper to use, or {@code null} to revert to the default instance.

--- a/src/main/java/ch/usi/si/seart/cloc/MD5.java
+++ b/src/main/java/ch/usi/si/seart/cloc/MD5.java
@@ -1,0 +1,29 @@
+package ch.usi.si.seart.cloc;
+
+import java.io.File;
+import java.io.IOException;
+import java.io.InputStream;
+import java.math.BigInteger;
+import java.nio.file.Files;
+import java.security.DigestInputStream;
+import java.security.MessageDigest;
+import java.security.NoSuchAlgorithmException;
+
+class MD5 {
+
+    private MD5() {
+    }
+
+    @SuppressWarnings({"checkstyle:EmptyStatement", "StatementWithEmptyBody"})
+    static String hash(File file) throws IOException, NoSuchAlgorithmException {
+        try (
+            InputStream fileStream = Files.newInputStream(file.toPath());
+            DigestInputStream digestStream = new DigestInputStream(fileStream, MessageDigest.getInstance("MD5"))
+        ) {
+            byte[] buffer = new byte[8192];
+            while (digestStream.read(buffer, 0, buffer.length) != -1);
+            byte[] digested = digestStream.getMessageDigest().digest();
+            return new BigInteger(1, digested).toString(16);
+        }
+    }
+}

--- a/src/main/resources/cloc.properties
+++ b/src/main/resources/cloc.properties
@@ -1,2 +1,3 @@
 cloc.url=${cloc.url}
 cloc.version=${cloc.version}
+cloc.md5=${cloc.md5}

--- a/src/test/java/ch/usi/si/seart/cloc/CLOCTest.java
+++ b/src/test/java/ch/usi/si/seart/cloc/CLOCTest.java
@@ -93,4 +93,11 @@ class CLOCTest {
         Assertions.assertNotNull(version, "Version should not be null.");
         Assertions.assertFalse(version.isEmpty(), "Version should not be empty.");
     }
+
+    @Test
+    void testGetMD5() {
+        String md5 = CLOC.getMD5();
+        Assertions.assertNotNull(md5, "MD5 should not be null.");
+        Assertions.assertFalse(md5.isEmpty(), "MD5 should not be empty.");
+    }
 }


### PR DESCRIPTION
This PR streamlines several aspects related to how this library works, namely:

- Windows executable has been removed in favor of solely using the Perl script, thus reducing the overall JAR size;
- Bundled script location is now lazily initialised only on request;
- Said script is kept between runs, with the user home directory serving as the cache.

These changes respectively lead to the following considerations:

- The Perl interpreter has to be installed and located on the user's `PATH` in order for the library to work as it did before;
- Volatile static fields and double-locking synchronization are needed for consistent accesses in threaded scenarios;
- MD5 checksums are now needed to validate when the cached script has been updated and requires replacement.

Closes #40